### PR TITLE
Add an alias for adios-db to mimic PyPI behavior

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -25,6 +25,9 @@ jobs:
 
   - script: |
         export CI=azure
+        export flow_run_id=azure_$(Build.BuildNumber).$(System.JobAttempt)
+        export remote_url=$(Build.Repository.Uri)
+        export sha=$(Build.SourceVersion)
         export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
         export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
         if [[ "${BUILD_REASON:-}" == "PullRequest" ]]; then

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,24 @@
-*.pyc
+# User content belongs under recipe/.
+# Feedstock configuration goes in `conda-forge.yml`
+# Everything else is managed by the conda-smithy rerender process.
+# Please do not modify
 
-build_artifacts
+# Ignore all files and folders in root
+*
+!/conda-forge.yml
+
+# Don't ignore any files/folders if the parent folder is 'un-ignored'
+# This also avoids warnings when adding an already-checked file with an ignored parent.
+!/**/
+# Don't ignore any files/folders recursively in the following folders
+!/recipe/**
+!/.ci_support/**
+
+# Since we ignore files/folders recursively, any folders inside
+# build_artifacts gets ignored which trips some build systems.
+# To avoid that we 'un-ignore' all files/folders recursively
+# and only ignore the root build_artifacts folder.
+!/build_artifacts/**
+/build_artifacts
+
+*.pyc

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -28,13 +28,15 @@ conda-build:
 pkgs_dirs:
   - ${FEEDSTOCK_ROOT}/build_artifacts/pkg_cache
   - /opt/conda/pkgs
+solver: libmamba
 
 CONDARC
+export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 mamba install --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build boa conda-forge-ci-setup=3
+    pip mamba conda-build boa conda-forge-ci-setup=4
 mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build boa conda-forge-ci-setup=3
+    pip mamba conda-build boa conda-forge-ci-setup=4
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
@@ -65,7 +67,8 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
 else
     conda mambabuild "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
-        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
+        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" \
+        --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"
     ( startgroup "Validating outputs" ) 2> /dev/null
 
     validate_recipe_outputs "${FEEDSTOCK_NAME}"

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -21,6 +21,12 @@ if [ -z ${FEEDSTOCK_NAME} ]; then
     export FEEDSTOCK_NAME=$(basename ${FEEDSTOCK_ROOT})
 fi
 
+if [[ "${sha:-}" == "" ]]; then
+  pushd "${FEEDSTOCK_ROOT}"
+  sha=$(git rev-parse HEAD)
+  popd
+fi
+
 docker info
 
 # In order for the conda-build process in the container to write to the mounted
@@ -91,6 +97,9 @@ docker run ${DOCKER_RUN_ARGS} \
            -e CPU_COUNT \
            -e BUILD_WITH_CONDA_DEBUG \
            -e BUILD_OUTPUT_ID \
+           -e flow_run_id \
+           -e remote_url \
+           -e sha \
            -e BINSTAR_TOKEN \
            -e FEEDSTOCK_TOKEN \
            -e STAGING_BINSTAR_TOKEN \

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Current release info
 
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-adios--db-green.svg)](https://anaconda.org/conda-forge/adios-db) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/adios-db.svg)](https://anaconda.org/conda-forge/adios-db) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/adios-db.svg)](https://anaconda.org/conda-forge/adios-db) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/adios-db.svg)](https://anaconda.org/conda-forge/adios-db) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-adios_db-green.svg)](https://anaconda.org/conda-forge/adios_db) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/adios_db.svg)](https://anaconda.org/conda-forge/adios_db) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/adios_db.svg)](https://anaconda.org/conda-forge/adios_db) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/adios_db.svg)](https://anaconda.org/conda-forge/adios_db) |
 
 Installing adios_db
@@ -52,41 +53,41 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `adios_db` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `adios-db, adios_db` can be installed with `conda`:
 
 ```
-conda install adios_db
-```
-
-or with `mamba`:
-
-```
-mamba install adios_db
-```
-
-It is possible to list all of the versions of `adios_db` available on your platform with `conda`:
-
-```
-conda search adios_db --channel conda-forge
+conda install adios-db adios_db
 ```
 
 or with `mamba`:
 
 ```
-mamba search adios_db --channel conda-forge
+mamba install adios-db adios_db
+```
+
+It is possible to list all of the versions of `adios-db` available on your platform with `conda`:
+
+```
+conda search adios-db --channel conda-forge
+```
+
+or with `mamba`:
+
+```
+mamba search adios-db --channel conda-forge
 ```
 
 Alternatively, `mamba repoquery` may provide more information:
 
 ```
 # Search all versions available on your platform:
-mamba repoquery search adios_db --channel conda-forge
+mamba repoquery search adios-db --channel conda-forge
 
-# List packages depending on `adios_db`:
-mamba repoquery whoneeds adios_db --channel conda-forge
+# List packages depending on `adios-db`:
+mamba repoquery whoneeds adios-db --channel conda-forge
 
-# List dependencies of `adios_db`:
-mamba repoquery depends adios_db --channel conda-forge
+# List dependencies of `adios-db`:
+mamba repoquery depends adios-db --channel conda-forge
 ```
 
 
@@ -108,7 +109,7 @@ available continuous integration services. Thanks to the awesome service provide
 [CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/),
 [Drone](https://cloud.drone.io/welcome), and [TravisCI](https://travis-ci.com/)
 it is possible to build and upload installable packages to the
-[conda-forge](https://anaconda.org/conda-forge) [Anaconda-Cloud](https://anaconda.org/)
+[conda-forge](https://anaconda.org/conda-forge) [anaconda.org](https://anaconda.org/)
 channel for Linux, Windows and OSX respectively.
 
 To manage the continuous integration and simplify feedstock maintenance

--- a/recipe/build_base.sh
+++ b/recipe/build_base.sh
@@ -1,0 +1,1 @@
+cd adios_db && ${PYTHON} -m pip install . --no-deps -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,31 +10,42 @@ source:
   sha256: 9744d3de0de30990309696b1f05e32076197914d94a1275895a108f2ababe42e
 
 build:
+  number: 1
   noarch: python
-  script: cd adios_db && {{ PYTHON }} -m pip install . -vv
-  number: 0
-  entry_points:
-    - adios_db_init = adios_db.scripts.db_initialize:init_db_cmd
-    - adios_db_import = adios_db.scripts.db_import:import_db_cmd
-    - adios_db_oil_query = adios_db.scripts.oil_query:oil_query_cmd
-    - adios_db_backup = adios_db.scripts.db_backup:backup_db_cmd
-    - adios_db_restore = adios_db.scripts.db_restore:restore_db_cmd
-    - adios_db_validate = adios_db.scripts.validate:main
-    - adios_db_update_test_data = adios_db.scripts.update_test_data:main
-    - adios_db_process_json = adios_db.scripts.process_json:run_through
 
-requirements:
-  host:
-    - python >=3.8
-    - pip
-  run:
-    - python >=3.8
-    - numpy >=1.20
-    - pynucos >=2.12
+outputs:
+  - name: adios_db
+    script: build_base.sh
+    entry_points:
+      - adios_db_init = adios_db.scripts.db_initialize:init_db_cmd
+      - adios_db_import = adios_db.scripts.db_import:import_db_cmd
+      - adios_db_oil_query = adios_db.scripts.oil_query:oil_query_cmd
+      - adios_db_backup = adios_db.scripts.db_backup:backup_db_cmd
+      - adios_db_restore = adios_db.scripts.db_restore:restore_db_cmd
+      - adios_db_validate = adios_db.scripts.validate:main
+      - adios_db_update_test_data = adios_db.scripts.update_test_data:main
+      - adios_db_process_json = adios_db.scripts.process_json:run_through
+    requirements:
+      host:
+        - python >=3.8
+        - pip
+      run:
+        - python >=3.8
+        - numpy >=1.20
+        - pynucos >=2.12
+    test:
+      imports:
+        - adios_db
 
-test:
-  imports:
-    - adios_db
+  - name: adios-db
+    build:
+      noarch: generic
+    requirements:
+      run:
+        - {{ pin_subpackage('adios_db', max_pin="x.x.x") }}
+    test:
+      imports:
+        - adios_db
 
 about:
   home: https://github.com/NOAA-ORR-ERD/adios_oil_database


### PR DESCRIPTION
Some user may think that adios-db is not available b/c on PyPI both `-` and `_` are allowed. This adds an alias so both names are build.